### PR TITLE
Labymod support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>4.1.59.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>

--- a/src/main/java/com/github/juliarn/npc/NPC.java
+++ b/src/main/java/com/github/juliarn/npc/NPC.java
@@ -5,6 +5,7 @@ import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import com.comphenix.protocol.wrappers.WrappedSignedProperty;
 import com.github.juliarn.npc.modifier.AnimationModifier;
 import com.github.juliarn.npc.modifier.EquipmentModifier;
+import com.github.juliarn.npc.modifier.LabyModModifier;
 import com.github.juliarn.npc.modifier.MetadataModifier;
 import com.github.juliarn.npc.modifier.RotationModifier;
 import com.github.juliarn.npc.modifier.VisibilityModifier;
@@ -249,6 +250,17 @@ public class NPC {
   @NotNull
   public VisibilityModifier visibility() {
     return new VisibilityModifier(this);
+  }
+
+  /**
+   * Creates a new labymod modifier which serves methods to play emotes and stickers.
+   *
+   * @return a labymod modifier modifying this NPC
+   * @since 2.5-SNAPSHOT
+   */
+  @NotNull
+  public LabyModModifier labymod() {
+    return new LabyModModifier(this);
   }
 
   /**

--- a/src/main/java/com/github/juliarn/npc/modifier/LabyModModifier.java
+++ b/src/main/java/com/github/juliarn/npc/modifier/LabyModModifier.java
@@ -129,7 +129,7 @@ public class LabyModModifier extends NPCModifier {
     EMOTE("emote_api", "emote_id"),
     /**
      * Plays a sticker to the client. For a overview of all stickers see
-     * <a href="https://dl.labymod.net/stickers.json>here</a>.
+     * <a href="https://dl.labymod.net/stickers.json">here</a>.
      */
     STICKER("sticker_api", "sticker_id");
 

--- a/src/main/java/com/github/juliarn/npc/modifier/LabyModModifier.java
+++ b/src/main/java/com/github/juliarn/npc/modifier/LabyModModifier.java
@@ -1,0 +1,176 @@
+package com.github.juliarn.npc.modifier;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.utility.MinecraftReflection;
+import com.comphenix.protocol.wrappers.MinecraftKey;
+import com.github.juliarn.npc.NPC;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A modifier for modifying playing labymod emotes and stickers.
+ *
+ * @since 2.5-SNAPSHOT
+ */
+public class LabyModModifier extends NPCModifier {
+
+  private static final String LMC_CHANNEL_NAME = "LMC";
+  private static final MinecraftKey MODERN_LMC_CHANNEL = new MinecraftKey("labymod", "main");
+
+  /**
+   * Creates a new modifier.
+   *
+   * @param npc The npc this modifier is for.
+   * @see NPC#equipment()
+   */
+  @ApiStatus.Internal
+  public LabyModModifier(@NotNull NPC npc) {
+    super(npc);
+  }
+
+  /**
+   * Queues the play of an emote or sticker.
+   *
+   * @param action             The action to play.
+   * @param playbackIdentifier The identifier of the action (emote or sticker id)
+   * @return The same instance of this class, for chaining.
+   */
+  @NotNull
+  public LabyModModifier queue(@NotNull LabyModAction action, int playbackIdentifier) {
+    PacketContainer container = super.newContainer(PacketType.Play.Server.CUSTOM_PAYLOAD, false);
+    container.getModifier()
+      .withType(ByteBuf.class)
+      .write(0, MinecraftReflection.getPacketDataSerializer(this.createContent(action, playbackIdentifier)));
+
+    if (MINECRAFT_VERSION >= 13) {
+      container.getMinecraftKeys().write(0, MODERN_LMC_CHANNEL);
+    } else {
+      container.getStrings().write(0, LMC_CHANNEL_NAME);
+    }
+
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void send(@NotNull Iterable<? extends Player> players) {
+    super.send(players, true);
+  }
+
+  /**
+   * Creates the lmc message contents for write into a data serializer.
+   *
+   * @param action             The action to play.
+   * @param playbackIdentifier The identifier of the action (emote or sticker id)
+   * @return The lmc message contents written into a byte buf.
+   */
+  @NotNull
+  protected ByteBuf createContent(@NotNull LabyModAction action, int playbackIdentifier) {
+    ByteBuf byteBuf = Unpooled.buffer();
+    this.writeString(byteBuf, action.messageKey);
+
+    JsonArray array = new JsonArray();
+    JsonObject data = new JsonObject();
+
+    data.addProperty("uuid", super.npc.getProfile().getUniqueId().toString());
+    data.addProperty(action.objectPropertyName, playbackIdentifier);
+
+    array.add(data);
+    this.writeString(byteBuf, array.toString());
+
+    return byteBuf;
+  }
+
+  /**
+   * Writes a string into the given byte buf.
+   *
+   * @param byteBuf The byte buf to write the data to.
+   * @param string  The string to write into the byte buf.
+   */
+  protected void writeString(@NotNull ByteBuf byteBuf, @NotNull String string) {
+    byte[] values = string.getBytes(StandardCharsets.UTF_8);
+    this.writeVarInt(byteBuf, values.length);
+    byteBuf.writeBytes(values);
+  }
+
+  /**
+   * Writes a var int into the specified byte buf as defined by google in
+   * <a href="https://developers.google.com/protocol-buffers/docs/encoding#varints">Base 128 Varints</a>.
+   *
+   * @param byteBuf The byte buf to write the int to.
+   * @param value   The int value to write into the byte buf.
+   */
+  protected void writeVarInt(@NotNull ByteBuf byteBuf, int value) {
+    while ((value & -128) != 0) {
+      byteBuf.writeByte(value & 127 | 128);
+      value >>>= 7;
+    }
+    byteBuf.writeByte(value);
+  }
+
+  /**
+   * A LabyMod action which can be played to a user using an npc.
+   */
+  public enum LabyModAction {
+    /**
+     * Plays an emote to the client. For a overview of all emotes see
+     * <a href="https://docs.labymod.net/pages/server/emote_api/">here</a>.
+     */
+    EMOTE("emote_api", "emote_id"),
+    /**
+     * Plays a sticker to the client. For a overview of all stickers see
+     * <a href="https://dl.labymod.net/stickers.json>here</a>.
+     */
+    STICKER("sticker_api", "sticker_id");
+
+    /**
+     * The message key of the message send to the lmc channel.
+     */
+    private final String messageKey;
+    /**
+     * The property name of the action identifier in the backing json object.
+     */
+    private final String objectPropertyName;
+
+    /**
+     * Constructs a new laby mod action.
+     *
+     * @param messageKey         The message key of the message send to the lmc channel.
+     * @param objectPropertyName The property name of the action identifier in the backing json object.
+     */
+    LabyModAction(String messageKey, String objectPropertyName) {
+      this.messageKey = messageKey;
+      this.objectPropertyName = objectPropertyName;
+    }
+
+    /**
+     * Get the message key of the message send to the lmc channel.
+     *
+     * @return the message key of the message send to the lmc channel.
+     */
+    @NotNull
+    public String getMessageKey() {
+      return this.messageKey;
+    }
+
+    /**
+     * Get he property name of the action identifier in the backing json object.
+     *
+     * @return the property name of the action identifier in the backing json object.
+     */
+    @NotNull
+    public String getObjectPropertyName() {
+      return this.objectPropertyName;
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds support for labymod emotes and stickers to the lib. This feature is currently only available on servers <= 1.12 as the channel identifier handling changed in 1.13+ and the client will not handle the message then.