### PR TITLE
Allow properties in npc and npc pool

### DIFF
--- a/src/main/java/com/github/juliarn/npc/modifier/VisibilityModifier.java
+++ b/src/main/java/com/github/juliarn/npc/modifier/VisibilityModifier.java
@@ -6,7 +6,10 @@ import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.comphenix.protocol.wrappers.PlayerInfoData;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.WrappedSignedProperty;
 import com.github.juliarn.npc.NPC;
+import com.github.juliarn.npc.profile.Profile;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,16 +46,42 @@ public class VisibilityModifier extends NPCModifier {
   /**
    * Enqueues the change of the player list for the wrapped npc.
    *
+   * @param action  The action of the player list change.
+   * @param profile The profile the npc should have, only the profile properties are copied and used.
+   * @return The same instance of this class, for chaining.
+   * @since 2.5-SNAPSHOT
+   */
+  @NotNull
+  public VisibilityModifier queuePlayerListChange(@NotNull PlayerInfoAction action, @NotNull Profile profile) {
+    return this.queuePlayerListChange(action.handle, this.convertProfile(profile));
+  }
+
+  /**
+   * Enqueues the change of the player list for the wrapped npc.
+   *
    * @param action The action of the player list change as a protocol lib wrapper.
    * @return The same instance of this class, for chaining.
    */
   @NotNull
   public VisibilityModifier queuePlayerListChange(@NotNull EnumWrappers.PlayerInfoAction action) {
+    return this.queuePlayerListChange(action, super.npc.getGameProfile());
+  }
+
+  /**
+   * Enqueues the change of the player list for the wrapped npc.
+   *
+   * @param action  The action of the player list change as a protocol lib wrapper.
+   * @param profile The profile the npc should have, only the profile properties are copied and used.
+   * @return The same instance of this class, for chaining.
+   * @since 2.5-SNAPSHOT
+   */
+  @NotNull
+  public VisibilityModifier queuePlayerListChange(@NotNull EnumWrappers.PlayerInfoAction action, @NotNull WrappedGameProfile profile) {
     PacketContainer packetContainer = super.newContainer(PacketType.Play.Server.PLAYER_INFO, false);
     packetContainer.getPlayerInfoAction().write(0, action);
 
     PlayerInfoData playerInfoData = new PlayerInfoData(
-      super.npc.getGameProfile(),
+      this.copyProfileProperties(profile),
       20,
       EnumWrappers.NativeGameMode.NOT_SET,
       WrappedChatComponent.fromText("")
@@ -60,6 +89,41 @@ public class VisibilityModifier extends NPCModifier {
     packetContainer.getPlayerInfoDataLists().write(0, Collections.singletonList(playerInfoData));
 
     return this;
+  }
+
+  /**
+   * Converts a profile to a protocol lib profile wrapper.
+   *
+   * @param profile The profile to convert.
+   * @return The protocol lib wrapper.
+   * @since 2.5-SNAPSHOT
+   */
+  @NotNull
+  protected WrappedGameProfile convertProfile(@NotNull Profile profile) {
+    WrappedGameProfile gameProfile = new WrappedGameProfile(super.npc.getProfile().getUniqueId(), super.npc.getProfile().getName());
+    profile.getProperties().forEach(property -> gameProfile.getProperties().put(
+      property.getName(),
+      new WrappedSignedProperty(property.getName(), property.getValue(), property.getSignature())
+    ));
+    return gameProfile;
+  }
+
+  /**
+   * Copies all profile properties from the given {@code profile} to a new profile which has the same unique id and name
+   * than the wrapped npc.
+   *
+   * @param profile The profile to copy the properties from.
+   * @return The created profile with the copied properties.
+   * @since 2.5-SNAPSHOT
+   */
+  @NotNull
+  protected WrappedGameProfile copyProfileProperties(@NotNull WrappedGameProfile profile) {
+    WrappedGameProfile gameProfile = new WrappedGameProfile(super.npc.getProfile().getUniqueId(), super.npc.getProfile().getName());
+    profile.getProperties().asMap().values().forEach(properties -> properties.forEach(property -> gameProfile.getProperties().put(
+      property.getName(),
+      new WrappedSignedProperty(property.getName(), property.getValue(), property.getSignature())
+    )));
+    return gameProfile;
   }
 
   /**

--- a/src/main/java/com/github/juliarn/npc/properties/Property.java
+++ b/src/main/java/com/github/juliarn/npc/properties/Property.java
@@ -1,0 +1,149 @@
+package com.github.juliarn.npc.properties;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A property which can be set into a {@link PropertyMap}.
+ *
+ * @param <T> The type of the value the property is holding.
+ * @since 2.5-SNAPSHOT
+ */
+public class Property<T> implements Cloneable {
+
+  private final String name;
+  private final AtomicReference<T> currentValue = new AtomicReference<>();
+
+  /**
+   * Creates a new property instance.
+   *
+   * @param name the name of the property to identify it.
+   */
+  protected Property(@NotNull String name) {
+    this.name = Preconditions.checkNotNull(name);
+  }
+
+  /**
+   * Creates a new property instance.
+   *
+   * @param name         the name of the property to identify it.
+   * @param defaultValue the default value of the property after creation.
+   */
+  protected Property(@NotNull String name, @Nullable T defaultValue) {
+    this.name = Preconditions.checkNotNull(name);
+    this.currentValue.set(defaultValue);
+  }
+
+  /**
+   * Creates a new property with the given name. The initial value is {@code null}.
+   *
+   * @param name The name of the property.
+   * @param <V>  The type of the value the property is holding.
+   * @return The created property.
+   */
+  @NotNull
+  public static <V> Property<V> named(@NotNull String name) {
+    return new Property<>(name);
+  }
+
+  /**
+   * Creates a new property with the given name and initial value.
+   *
+   * @param name         The name of the property.
+   * @param defaultValue The default value of the property.
+   * @param <V>          The type of the value the property is holding.
+   * @return The created property.
+   */
+  @NotNull
+  public static <V> Property<V> named(@NotNull String name, @NotNull V defaultValue) {
+    return new Property<>(name, defaultValue);
+  }
+
+  /**
+   * Get if this property has a value set.
+   *
+   * @return If this property has a value set.
+   */
+  public boolean hasValue() {
+    return this.currentValue.get() != null;
+  }
+
+  /**
+   * Get the current value of this property.
+   *
+   * @return the current value of this property.
+   */
+  @NotNull
+  public Optional<T> getValue() {
+    return Optional.ofNullable(this.currentValue.get());
+  }
+
+  /**
+   * Sets the current value of this property.
+   *
+   * @param newValue The new value of this property.
+   * @return The same instance of this class.
+   */
+  public Property<T> setCurrentValue(@Nullable T newValue) {
+    this.currentValue.set(newValue);
+    return this;
+  }
+
+  /**
+   * Gets the value without checking if the value is present.
+   *
+   * @return the value without checking if the value is present.
+   * @throws NullPointerException if the value is not present.
+   */
+  @NotNull
+  public T getValueUnchecked() {
+    return Preconditions.checkNotNull(this.currentValue.get(), "value");
+  }
+
+  /**
+   * Gets the current value of this property.
+   *
+   * @param def The value to get when this property has no value set.
+   * @return The value of this property or {@code def} if this property has no value.
+   */
+  @NotNull
+  public T getValue(@NotNull T def) {
+    T current = this.currentValue.get();
+    return current == null ? def : current;
+  }
+
+  /**
+   * Get the name of this property. A name is unique in a {@link PropertyMap}.
+   *
+   * @return the name of this property.
+   */
+  @NotNull
+  public String getName() {
+    return this.name;
+  }
+
+  /**
+   * Converts this property to an unmodifiable property, returns the same instance if the
+   * property is already unmodifiable.
+   *
+   * @return this property as an unmodifiable property.
+   */
+  @NotNull
+  public UnmodifiableProperty<T> unmodifiable() {
+    return new UnmodifiableProperty<>(this.name, this.currentValue.get());
+  }
+
+  /**
+   * Creates a clone of this property without cloning the current value of it.
+   *
+   * @return a clone of this property without cloning the current value of it.
+   */
+  @NotNull
+  public Property<T> shallowClone() {
+    return new Property<>(this.name, this.currentValue.get());
+  }
+}

--- a/src/main/java/com/github/juliarn/npc/properties/PropertyMap.java
+++ b/src/main/java/com/github/juliarn/npc/properties/PropertyMap.java
@@ -1,0 +1,136 @@
+package com.github.juliarn.npc.properties;
+
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A map which associates a property name with the property instance.
+ *
+ * @since 2.5-SNAPSHOT
+ */
+public class PropertyMap {
+
+  private final Map<String, Property<?>> properties = new ConcurrentHashMap<>();
+
+  /**
+   * Checks if this property map holds an associated property for the given {@code name}.
+   *
+   * @param name The name of the property to check.
+   * @return If this map has an associated property with the given {@code name}.
+   */
+  public boolean hasProperty(@NotNull String name) {
+    return this.properties.containsKey(name);
+  }
+
+  /**
+   * Checks if this property map holds an associated property for the given {@code property}.
+   *
+   * @param property The property to check.
+   * @return If this map has an associated property with the given {@code property}.
+   */
+  public boolean hasProperty(@NotNull Property<?> property) {
+    return this.properties.containsKey(property.getName());
+  }
+
+  /**
+   * Gets a specific property with the given {@code name}.
+   *
+   * @param name The name of the property to get.
+   * @param <T>  The type of the property value to get.
+   * @return The property associated with the given {@code name}.
+   */
+  @NotNull
+  @SuppressWarnings("unchecked")
+  public <T> Optional<Property<T>> getProperty(@NotNull String name) {
+    Property<?> property = this.properties.get(name);
+    return Optional.ofNullable(property == null ? null : (Property<T>) property);
+  }
+
+  /**
+   * Gets a specific property with the given {@code property} name.
+   *
+   * @param property The property to get.
+   * @param <T>      The type of the property value to get.
+   * @return The property associated with the given {@code name}.
+   * @see #getProperty(String)
+   */
+  @NotNull
+  public <T> Optional<Property<T>> getProperty(@NotNull Property<?> property) {
+    return this.getProperty(property.getName());
+  }
+
+  /**
+   * Gets a property from this map without checking if the property is actually present.
+   *
+   * @param name The name of the property to get.
+   * @param <T>  The type of the property value to get.
+   * @return The property associated with the given {@code name}.
+   * @throws NullPointerException If there is no property associated with the given {@code name}.
+   */
+  @NotNull
+  @SuppressWarnings("unchecked")
+  public <T> Property<T> getPropertyUnchecked(@NotNull String name) {
+    Property<?> property = this.properties.get(name);
+    Preconditions.checkNotNull(property, "property");
+    return (Property<T>) property;
+  }
+
+  /**
+   * Gets a property from this map without checking if the property is actually present.
+   *
+   * @param property The property to get.
+   * @param <T>      The type of the property value to get.
+   * @return The property associated with the given {@code name}.
+   * @throws NullPointerException If there is no property associated with the given {@code name}.
+   * @see #getProperty(String)
+   */
+  @NotNull
+  public <T> Property<T> getPropertyUnchecked(@NotNull Property<T> property) {
+    return this.getPropertyUnchecked(property.getName());
+  }
+
+  /**
+   * Sets a property into this map if there is no previous association with the given {@code property} name.
+   *
+   * @param property The property to set into this map.
+   */
+  public void setProperty(@NotNull Property<?> property) {
+    this.properties.putIfAbsent(property.getName(), property);
+  }
+
+  /**
+   * Removes a specific property from this map.
+   *
+   * @param property The property to remove.
+   */
+  public void removeProperty(@NotNull Property<?> property) {
+    this.properties.remove(property.getName());
+  }
+
+  /**
+   * Removes a specific property from this map.
+   *
+   * @param name The name of the property to remove.
+   */
+  public void removeProperty(@NotNull String name) {
+    this.properties.remove(name);
+  }
+
+  /**
+   * Get an unmodifiable copy of all properties added to this map.
+   *
+   * @return an unmodifiable copy of all properties added to this map.
+   */
+  @NotNull
+  @Unmodifiable
+  public Collection<Property<?>> getProperties() {
+    return Collections.unmodifiableCollection(this.properties.values());
+  }
+}

--- a/src/main/java/com/github/juliarn/npc/properties/UnmodifiableProperty.java
+++ b/src/main/java/com/github/juliarn/npc/properties/UnmodifiableProperty.java
@@ -1,0 +1,49 @@
+package com.github.juliarn.npc.properties;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A property which cannot be modified.
+ *
+ * @param <T> The type of the value the property is holding.
+ * @since 2.5-SNAPSHOT
+ */
+public class UnmodifiableProperty<T> extends Property<T> {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected UnmodifiableProperty(@NotNull String name, @Nullable T defaultValue) {
+    super(name, defaultValue);
+  }
+
+  /**
+   * Always throws an {@link UnsupportedOperationException} because it is not allowed
+   * to modify an unmodifiable property.
+   *
+   * @param newValue The new value of this property.
+   * @return Not reachable.
+   * @throws UnsupportedOperationException as this property is unmodifiable.
+   */
+  @Override
+  public UnmodifiableProperty<T> setCurrentValue(@Nullable T newValue) {
+    throw new UnsupportedOperationException("Property is unmodifiable");
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NotNull UnmodifiableProperty<T> unmodifiable() {
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NotNull UnmodifiableProperty<T> shallowClone() {
+    return new UnmodifiableProperty<>(this.getName(), this.getValue().orElse(null));
+  }
+}


### PR DESCRIPTION
Allows a map of properties in npc and npc pool. An npc can now have the skin of the target player instead of the defined skin too.