### PR TITLE
Fix minecraft 1.17.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ maven {
 }
 
 // latest stable release
-compile group: 'com.github.juliarn', name: 'npc-lib', version: '2.5-RELEASE'
+compile group: 'com.github.juliarn', name: 'npc-lib', version: '2.6-RELEASE'
 // latest build
 compile group: 'com.github.juliarn', name: 'npc-lib', version: 'development-SNAPSHOT'
 ```

--- a/src/main/java/com/github/juliarn/npc/modifier/VisibilityModifier.java
+++ b/src/main/java/com/github/juliarn/npc/modifier/VisibilityModifier.java
@@ -109,7 +109,7 @@ public class VisibilityModifier extends NPCModifier {
         .newContainer(PacketType.Play.Server.ENTITY_DESTROY, false);
 
     if (MINECRAFT_VERSION >= 17) {
-      packetContainer.getIntegers().write(0, super.npc.getEntityId());
+      packetContainer.getIntLists().write(0, Collections.singletonList(super.npc.getEntityId()));
     } else {
       packetContainer.getIntegerArrays().write(0, new int[]{super.npc.getEntityId()});
     }


### PR DESCRIPTION
Fixes removing NPCs in the 1.17.1 due to changed fields in the DestroyPacket.

Tested the lib ingame using CloudNet NPCs:
The NPCs work as expected.