### PR TITLE
Allow per-player packet building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.juliarn</groupId>
   <artifactId>npc-lib</artifactId>
-  <version>2.6-RELEASE</version>
+  <version>2.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/github/juliarn/npc/NPCPool.java
+++ b/src/main/java/com/github/juliarn/npc/NPCPool.java
@@ -15,6 +15,13 @@ import com.github.juliarn.npc.modifier.MetadataModifier;
 import com.github.juliarn.npc.modifier.NPCModifier;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -30,13 +37,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Represents the main management point for {@link NPC}s.
@@ -200,7 +200,8 @@ public class NPCPool implements Listener {
               npc.hide(player, this.plugin, PlayerNPCHideEvent.Reason.SPAWN_DISTANCE);
             }
             continue;
-          } else if (!npcLoc.getWorld().isChunkLoaded(npcLoc.getBlockX() >> 4, npcLoc.getBlockZ() >> 4)) {
+          } else if (!npcLoc.getWorld()
+              .isChunkLoaded(npcLoc.getBlockX() >> 4, npcLoc.getBlockZ() >> 4)) {
             if (npc.isShownFor(player)) {
               npc.hide(player, this.plugin, PlayerNPCHideEvent.Reason.UNLOADED_CHUNK);
             }

--- a/src/main/java/com/github/juliarn/npc/modifier/AnimationModifier.java
+++ b/src/main/java/com/github/juliarn/npc/modifier/AnimationModifier.java
@@ -1,6 +1,7 @@
 package com.github.juliarn.npc.modifier;
 
-import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.PacketType.Play.Server;
+import com.comphenix.protocol.events.PacketContainer;
 import com.github.juliarn.npc.NPC;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +41,13 @@ public class AnimationModifier extends NPCModifier {
    */
   @NotNull
   public AnimationModifier queue(int animationId) {
-    super.newContainer(PacketType.Play.Server.ANIMATION).getIntegers().write(1, animationId);
+    super.queueInstantly((targetNpc, target) -> {
+      PacketContainer container = new PacketContainer(Server.ANIMATION);
+      container.getIntegers()
+          .write(0, targetNpc.getEntityId())
+          .write(1, animationId);
+      return container;
+    });
     return this;
   }
 

--- a/src/main/java/com/github/juliarn/npc/modifier/NPCModifier.java
+++ b/src/main/java/com/github/juliarn/npc/modifier/NPCModifier.java
@@ -49,10 +49,25 @@ public class NPCModifier {
     this.npc = npc;
   }
 
+  /**
+   * Queues the packet for sending.
+   *
+   * @param packet the packet to queue.
+   * @since 2.7-SNAPSHOT
+   */
   protected void queuePacket(@NotNull LazyPacket packet) {
     this.packetContainers.add(packet);
   }
 
+  /**
+   * Queues the packet instantly meaning that the packet will be build and the memorized instance of
+   * the container will be sent to the target player(s). When using this method the target player
+   * normally supplied to {@code provide} will be {@code null} as the packet will be sent in the
+   * same form to all players.
+   *
+   * @param packet the packet to queue.
+   * @since 2.7-SNAPSHOT
+   */
   protected void queueInstantly(@NotNull LazyPacket packet) {
     PacketContainer container = packet.provide(this.npc, null);
     this.packetContainers.add(($, $1) -> container);
@@ -94,9 +109,21 @@ public class NPCModifier {
     this.send(Arrays.asList(targetPlayers));
   }
 
+  /**
+   * Represents a packet which gets build lazily, normally before sending to a player.
+   *
+   * @since 2.7-SNAPSHOT
+   */
   @FunctionalInterface
   public interface LazyPacket {
 
+    /**
+     * Builds the packet container which gets send to the player.
+     *
+     * @param targetNpc the npc of the modifier context the packet is build for.
+     * @param target    the target player to whom the packet will be sent.
+     * @return the constructed packet to send.
+     */
     @NotNull PacketContainer provide(@NotNull NPC targetNpc, @UnknownNullability Player target);
   }
 }

--- a/src/main/java/com/github/juliarn/npc/profile/ProfileUtils.java
+++ b/src/main/java/com/github/juliarn/npc/profile/ProfileUtils.java
@@ -5,16 +5,35 @@ import com.comphenix.protocol.wrappers.WrappedSignedProperty;
 import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Small utility class around profiles.
+ *
+ * @since 2.7-SNAPSHOT
+ */
 public final class ProfileUtils {
 
   private ProfileUtils() {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Creates a random name which is exactly 16 chars long and only contains alphabetic and numeric
+   * chars. The created name conforms to the Mojang naming convention as (for example) described
+   * <a href="https://help.minecraft.net/hc/en-us/articles/4408950195341-Minecraft-Java-Edition-Username-VS-Gamertag-FAQ">here</a>.
+   *
+   * @return a randomly created minecraft name.
+   */
   public static @NotNull String randomName() {
     return UUID.randomUUID().toString().replace("-", "").substring(0, 16);
   }
 
+  /**
+   * Converts the given {@link Profile} to a protocol lib wrapper copying the name, unique id and
+   * profile properties.
+   *
+   * @param profile the profile to convert.
+   * @return the created protocol lib wrapper of the profile.
+   */
   public static @NotNull WrappedGameProfile profileToWrapper(@NotNull Profile profile) {
     WrappedGameProfile wrapped = new WrappedGameProfile(profile.getUniqueId(), profile.getName());
     profile.getProperties().forEach(prop -> wrapped.getProperties().put(

--- a/src/main/java/com/github/juliarn/npc/profile/ProfileUtils.java
+++ b/src/main/java/com/github/juliarn/npc/profile/ProfileUtils.java
@@ -1,0 +1,25 @@
+package com.github.juliarn.npc.profile;
+
+import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.WrappedSignedProperty;
+import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
+
+public final class ProfileUtils {
+
+  private ProfileUtils() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static @NotNull String randomName() {
+    return UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+  }
+
+  public static @NotNull WrappedGameProfile profileToWrapper(@NotNull Profile profile) {
+    WrappedGameProfile wrapped = new WrappedGameProfile(profile.getUniqueId(), profile.getName());
+    profile.getProperties().forEach(prop -> wrapped.getProperties().put(
+        prop.getName(),
+        new WrappedSignedProperty(prop.getName(), prop.getValue(), prop.getSignature())));
+    return wrapped;
+  }
+}


### PR DESCRIPTION
This allows api  users to build packets when actually sending them to the client rather than statically once. As a "demo" I've provided support to let an npc use the skin of the player being spawned to rather than a fixed one.

Closes #22