### PR TITLE
Remove Streams in Sneak/Interact Events

### DIFF
--- a/src/main/java/com/github/juliarn/npc/NPCPool.java
+++ b/src/main/java/com/github/juliarn/npc/NPCPool.java
@@ -336,12 +336,15 @@ public class NPCPool implements Listener {
   public void handleSneak(PlayerToggleSneakEvent event) {
     Player player = event.getPlayer();
 
-    this.npcMap.values().stream()
-        .filter(npc -> npc.isImitatePlayer() && npc.isShownFor(player))
-        .filter(npc -> npc.getLocation().getWorld().equals(player.getWorld())
-            && npc.getLocation().distanceSquared(player.getLocation()) <= this.actionDistance)
-        .forEach(npc -> npc.metadata()
-            .queue(MetadataModifier.EntityMetadata.SNEAKING, event.isSneaking()).send(player));
+    for (NPC npc : this.npcMap.values()) {
+      if (npc.isImitatePlayer()
+          && npc.getLocation().getWorld().equals(player.getWorld())
+          && npc.isShownFor(player)
+          && npc.getLocation().distanceSquared(player.getLocation()) <= this.actionDistance) {
+        npc.metadata()
+            .queue(MetadataModifier.EntityMetadata.SNEAKING, event.isSneaking()).send(player);
+      }
+    }
   }
 
   @EventHandler
@@ -350,12 +353,15 @@ public class NPCPool implements Listener {
 
     if (event.getAction() == Action.LEFT_CLICK_AIR
         || event.getAction() == Action.LEFT_CLICK_BLOCK) {
-      this.npcMap.values().stream()
-          .filter(npc -> npc.isImitatePlayer() && npc.isShownFor(player))
-          .filter(npc -> npc.getLocation().getWorld().equals(player.getWorld())
-              && npc.getLocation().distanceSquared(player.getLocation()) <= this.actionDistance)
-          .forEach(npc -> npc.animation().queue(AnimationModifier.EntityAnimation.SWING_MAIN_ARM)
-              .send(player));
+      for (NPC npc : this.npcMap.values()) {
+        if (npc.isImitatePlayer()
+            && npc.getLocation().getWorld().equals(player.getWorld())
+            && npc.isShownFor(player)
+            && npc.getLocation().distanceSquared(player.getLocation()) <= this.actionDistance) {
+          npc.animation().queue(AnimationModifier.EntityAnimation.SWING_MAIN_ARM)
+              .send(player);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Streams have very poor overall performance, and are especially rough to use in hot code. Players sneak and Interact _constantly_, and at scale, usage of streams here was causing up to 1.5% of my server's tick with around 1400+ NPCs in the `npcMap`.

Simple for-loops are generally best performance. In addition, I reordered the checks to be the most performant (boolean check, then equals check, reserving map lookup for `isShownFor `and finally distance check for last). After these changes, I didn't even see the events show up in my profiler.

In my personal case, we don't even _use_ imitating NPCs, so the best possible performance here would really be to cache into a separate map only the NPCs that imitate, but that might be a micro-optimization for most use cases unless people have thousands and thousands of NPCs.