### PR TITLE
Hologram lib integration for multiple lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
       <artifactId>gson</artifactId>
       <version>2.8.9</version>
     </dependency>
-    <dependency>
-      <groupId>com.github.unldenis</groupId>
-      <artifactId>Hologram-Lib</artifactId>
-      <version>master-SNAPSHOT</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.9</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.unldenis</groupId>
+      <artifactId>Hologram-Lib</artifactId>
+      <version>master-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/github/juliarn/npc/NPCHologram.java
+++ b/src/main/java/com/github/juliarn/npc/NPCHologram.java
@@ -1,0 +1,42 @@
+package com.github.juliarn.npc;
+
+import com.github.unldenis.hologram.Hologram;
+import com.github.unldenis.hologram.line.AbstractLine;
+import com.github.unldenis.hologram.placeholder.Placeholders;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import java.util.Collection;
+
+public class NPCHologram extends Hologram {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Deprecated
+  @ApiStatus.Internal
+  public NPCHologram(@NotNull Plugin plugin, @NotNull Location location,
+      @Nullable Placeholders placeholders, @NotNull Collection<Player> seeingPlayers,
+      @NotNull Object... lines) {
+    super(plugin, location, placeholders, seeingPlayers, lines);
+  }
+
+  @Override
+  protected void show(@NotNull Player player) {
+    for(AbstractLine<?> line: this.lines) {
+      line.show(player);
+    }
+  }
+
+  @Override
+  protected void hide(@NotNull Player player) {
+    for(AbstractLine<?> line: this.lines) {
+      line.hide(player);
+    }
+  }
+
+}

--- a/src/main/java/com/github/juliarn/npc/NPCPool.java
+++ b/src/main/java/com/github/juliarn/npc/NPCPool.java
@@ -45,7 +45,7 @@ public class NPCPool implements Listener {
 
   private static final Random RANDOM = new Random();
 
-  private final Plugin plugin;
+  protected final Plugin plugin;
 
   private final double spawnDistance;
   private final double actionDistance;

--- a/src/main/java/com/github/juliarn/npc/profile/Profile.java
+++ b/src/main/java/com/github/juliarn/npc/profile/Profile.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +45,7 @@ public class Profile implements Cloneable {
   private static final Type PROPERTY_LIST_TYPE = TypeToken
       .getParameterized(Set.class, Property.class).getType();
 
-  private String name;
+  private String name = new UUID(new Random().nextLong(), 0).toString().substring(0, 16);
   private UUID uniqueId;
   private Collection<Property> properties;
 
@@ -95,10 +96,9 @@ public class Profile implements Cloneable {
    */
   public Profile(UUID uniqueId, String name, Collection<Property> properties) {
     Preconditions
-        .checkArgument(name != null || uniqueId != null, "Either name or uniqueId must be given!");
+        .checkArgument(uniqueId != null, "Either name or uniqueId must be given!");
 
     this.uniqueId = uniqueId;
-    this.name = name;
     this.properties = properties;
   }
 
@@ -274,7 +274,10 @@ public class Profile implements Cloneable {
    *
    * @param name the new name of this profile.
    * @return the same profile instance, for chaining.
+   * @deprecated Holograms are used for the name from now on
    */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval
   @NotNull
   public Profile setName(String name) {
     this.name = name;


### PR DESCRIPTION
Given the need to create npc with multiple name lines, #56 #48 I implemented my new <a href="https://github.com/unldenis/Hologram-Lib">Hologram-Lib</a> library in this one.
(Already tried and everything seems to work.)
My library uses ProtocolLib to create holograms with different features
(You can also contribute in case).

In the integration I created a subclass of Hologram because the two show and hide methods in the library removed it from the list of seeing players.

The most essential thing was to create the teams to remove the npc nametag.

I don't think I need to comment on everything since my hologram library is also open source, but if you need to, I'll answer it.

A simple use:
```java
public void appendNPC(Location location) {
        // building the NPC
        NPC npc = NPC.builder()
                .profile(this.createProfile())
                .location(location)
                .imitatePlayer(false)
                .lookAtPlayer(false)
                .addLine("Hello world")
                .addLine("Hello %%player%%")
                .addLine(new ItemStack(Material.EMERALD_BLOCK))
                .addPlaceholder("%%player%%", Player::getName)
                // appending it to the NPC pool
                .build(this.npcPool);

        npc.hologram().setAnimation(2, AnimationType.CIRCLE);
}
```
Preview:
![2022-01-06_20 03 15](https://user-images.githubusercontent.com/80055679/148437048-7f1b6a7a-8358-49fc-b255-c8644fe21dfd.png)

