### PR TITLE
Fix that the left clicks (in the air) are not imitated

### DIFF
--- a/bukkit/src/main/java/com/github/juliarn/npclib/bukkit/BukkitActionController.java
+++ b/bukkit/src/main/java/com/github/juliarn/npclib/bukkit/BukkitActionController.java
@@ -169,7 +169,7 @@ public final class BukkitActionController extends CommonNpcActionController impl
     }
   }
 
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR)
   public void handleLeftClick(@NotNull PlayerInteractEvent event) {
     if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
       Player player = event.getPlayer();


### PR DESCRIPTION
Currently the listener for the PlayerInteractEvent has `ignoreCancelled` set to `true`. The problem with this is that the PlayerInteractEvent is cancelled if the click was into the air. Therefore this PR sets `ignoreCancelled` to `false` inorder to dispatch the clicks correctly.