### PR TITLE
Added CodeMC repository as advised by one of the packetevents devs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,16 @@ allprojects {
         snapshotsOnly()
       }
     }
+    maven(url = "https://repo.codemc.io/repository/maven-public/") {
+      mavenContent {
+        releasesOnly()
+      }
+    }
+    maven(url = "https://repo.codemc.io/repository/maven-snapshots/") {
+      mavenContent {
+        snapshotsOnly()
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The packetevents library on Jitpack was recently unavailable. I went to the packetevents support Discord server and they advised me to use CodeMC instead of JitPack.