### PR TITLE
bugfix for LOOK_AT_PLAYER

### DIFF
--- a/bukkit/src/main/java/com/github/juliarn/npclib/bukkit/BukkitActionController.java
+++ b/bukkit/src/main/java/com/github/juliarn/npclib/bukkit/BukkitActionController.java
@@ -148,7 +148,7 @@ public final class BukkitActionController extends CommonNpcActionController impl
         }
 
         // check if we should rotate the npc towards the player
-        if (changedOrientation
+        if ((changedOrientation || changedPosition)
           && npc.tracksPlayer(player)
           && distance <= this.imitateDistance
           && npc.flagValueOrDefault(Npc.LOOK_AT_PLAYER)) {


### PR DESCRIPTION
In the current version the npc doesn't look at the player as long as the player doesn't change his orientation. This allows the player to move around without touching the mouse to "freeze" the npc orientation.
This PR fixes that bug with an entire line of code.