### PR TITLE
feat: use custom event handling over external dependency

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -182,7 +182,7 @@
       <option name="FOR_BRACE_FORCE" value="3" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -25,7 +25,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 dependencies {
-  api(libs.event)
   implementation(libs.gson)
 }
 

--- a/api/src/main/java/com/github/juliarn/npclib/api/event/CancellableNpcEvent.java
+++ b/api/src/main/java/com/github/juliarn/npclib/api/event/CancellableNpcEvent.java
@@ -24,8 +24,9 @@
 
 package com.github.juliarn.npclib.api.event;
 
-import com.seiama.event.Cancellable;
+public interface CancellableNpcEvent extends NpcEvent {
 
-public interface CancellableNpcEvent extends Cancellable {
+  boolean cancelled();
 
+  void cancelled(boolean cancelled);
 }

--- a/api/src/main/java/com/github/juliarn/npclib/api/event/manager/DefaultNpcEventManager.java
+++ b/api/src/main/java/com/github/juliarn/npclib/api/event/manager/DefaultNpcEventManager.java
@@ -24,93 +24,113 @@
 
 package com.github.juliarn.npclib.api.event.manager;
 
+import com.github.juliarn.npclib.api.event.CancellableNpcEvent;
 import com.github.juliarn.npclib.api.event.NpcEvent;
 import com.github.juliarn.npclib.api.log.PlatformLogger;
-import com.seiama.event.EventConfig;
-import com.seiama.event.EventSubscription;
-import com.seiama.event.bus.EventBus;
-import com.seiama.event.bus.SimpleEventBus;
-import com.seiama.event.registry.EventRegistry;
-import com.seiama.event.registry.SimpleEventRegistry;
-import java.util.OptionalInt;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
 import org.jetbrains.annotations.NotNull;
 
 final class DefaultNpcEventManager implements NpcEventManager {
 
-  private final EventBus<NpcEvent> eventBus;
-  private final EventRegistry<NpcEvent> eventRegistry;
+  private static final Comparator<NpcEventSubscription<? super NpcEvent>> SUBSCRIPTION_COMPARABLE =
+    Comparator.comparingInt(NpcEventSubscription::order);
+
+  private final boolean debugEnabled;
+  private final PlatformLogger platformLogger;
+
+  private final Map<Class<?>, List<NpcEventSubscription<? super NpcEvent>>> registeredSubscribers =
+    new ConcurrentHashMap<>(16, 0.9f, 1);
 
   public DefaultNpcEventManager(boolean debugEnabled, @NotNull PlatformLogger logger) {
-    this.eventRegistry = new SimpleEventRegistry<>(NpcEvent.class);
-    this.eventBus = new SimpleEventBus<>(this.eventRegistry, new LoggingEventExceptionHandler(debugEnabled, logger));
+    this.debugEnabled = debugEnabled;
+    this.platformLogger = logger;
+  }
+
+  private static boolean isEventCancelled(@NotNull NpcEvent event) {
+    return event instanceof CancellableNpcEvent && ((CancellableNpcEvent) event).cancelled();
   }
 
   @Override
   public <E extends NpcEvent> @NotNull E post(@NotNull E event) {
-    this.eventBus.post(event, OptionalInt.empty());
+    Objects.requireNonNull(event, "event");
+
+    List<NpcEventSubscription<? super NpcEvent>> subscriptions = this.registeredSubscribers.get(event.getClass());
+    if (!subscriptions.isEmpty()) {
+      for (NpcEventSubscription<? super E> subscription : subscriptions) {
+        // once the event was cancelled we don't want to post it to any further subscribers
+        boolean eventWasCancelled = isEventCancelled(event);
+        if (eventWasCancelled) {
+          break;
+        }
+
+        try {
+          subscription.eventConsumer().handle(event);
+        } catch (Throwable throwable) {
+          EventExceptionHandler.rethrowFatalException(throwable);
+          if (this.debugEnabled) {
+            // not a fatal exception but debug is enabled to we log it anyway
+            this.platformLogger.error(
+              String.format(
+                "Subscriber %s was unable to handle %s",
+                subscription.eventConsumer().getClass().getName(),
+                event.getClass().getSimpleName()),
+              throwable);
+          }
+        }
+      }
+    }
+
     return event;
   }
 
   @Override
-  public <E extends NpcEvent> @NotNull NpcEventManager registerEventHandler(
+  public <E extends NpcEvent> @NotNull NpcEventSubscription<? super E> registerEventHandler(
     @NotNull Class<E> eventType,
     @NotNull NpcEventConsumer<E> consumer
   ) {
-    return this.registerEventHandler(eventType, consumer, EventConfig.DEFAULT_ORDER);
+    return this.registerEventHandler(eventType, consumer, 0);
   }
 
   @Override
-  public <E extends NpcEvent> @NotNull NpcEventManager registerEventHandler(
+  @SuppressWarnings("unchecked")
+  public <E extends NpcEvent> @NotNull NpcEventSubscription<? super E> registerEventHandler(
     @NotNull Class<E> eventType,
     @NotNull NpcEventConsumer<E> consumer,
     int eventHandlerPriority
   ) {
-    EventConfig eventConfig = EventConfig.defaults().acceptsCancelled(false).order(eventHandlerPriority);
-    this.eventRegistry.subscribe(eventType, eventConfig, consumer::accept);
-    return this;
+    NpcEventSubscription<? super E> subscription = new DefaultNpcEventSubscription<>(
+      eventHandlerPriority,
+      eventType,
+      consumer,
+      this);
+
+    List<NpcEventSubscription<? super NpcEvent>> eventSubscriptions = this.registeredSubscribers.computeIfAbsent(
+      eventType,
+      __ -> new CopyOnWriteArrayList<>());
+    eventSubscriptions.add((NpcEventSubscription<? super NpcEvent>) subscription);
+
+    eventSubscriptions.sort(SUBSCRIPTION_COMPARABLE);
+    return subscription;
   }
 
-  private static final class LoggingEventExceptionHandler implements EventBus.EventExceptionHandler {
-
-    private final boolean debugEnabled;
-    private final PlatformLogger logger;
-
-    public LoggingEventExceptionHandler(boolean debugEnabled, @NotNull PlatformLogger logger) {
-      this.debugEnabled = debugEnabled;
-      this.logger = logger;
+  @Override
+  public void unregisterEventHandlerIf(@NotNull Predicate<NpcEventSubscription<? super NpcEvent>> subscriptionFilter) {
+    for (List<NpcEventSubscription<? super NpcEvent>> subscriptions : this.registeredSubscribers.values()) {
+      subscriptions.removeIf(subscriptionFilter);
     }
+  }
 
-    private static boolean isFatal(@NotNull Throwable throwable) {
-      // this includes the most fatal errors that can occur on a thread which we should not silently ignore and rethrow
-      return throwable instanceof InterruptedException
-        || throwable instanceof LinkageError
-        || throwable instanceof ThreadDeath
-        || throwable instanceof VirtualMachineError;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends Throwable> void throwUnchecked(@NotNull Throwable throwable) throws T {
-      throw (T) throwable;
-    }
-
-    @Override
-    public <E> void eventExceptionCaught(
-      @NotNull EventSubscription<? super E> subscription,
-      @NotNull E event,
-      @NotNull Throwable throwable
-    ) {
-      if (isFatal(throwable)) {
-        // rethrow fatal exceptions instantly
-        throwUnchecked(throwable);
-      } else if (this.debugEnabled) {
-        // just log that we received an exception from the event handler
-        this.logger.error(
-          String.format(
-            "Subscriber %s was unable to handle %s:",
-            subscription.subscriber().getClass().getName(),
-            event.getClass().getSimpleName()),
-          throwable);
-      }
+  void removeSubscription(@NotNull NpcEventSubscription<?> subscription) {
+    List<NpcEventSubscription<? super NpcEvent>> subscriptions = this.registeredSubscribers.get(
+      subscription.eventType());
+    if (subscriptions != null) {
+      subscriptions.remove(subscription);
     }
   }
 }

--- a/api/src/main/java/com/github/juliarn/npclib/api/event/manager/DefaultNpcEventSubscription.java
+++ b/api/src/main/java/com/github/juliarn/npclib/api/event/manager/DefaultNpcEventSubscription.java
@@ -27,8 +27,43 @@ package com.github.juliarn.npclib.api.event.manager;
 import com.github.juliarn.npclib.api.event.NpcEvent;
 import org.jetbrains.annotations.NotNull;
 
-@FunctionalInterface
-public interface NpcEventConsumer<E extends NpcEvent> {
+final class DefaultNpcEventSubscription<E extends NpcEvent> implements NpcEventSubscription<E> {
 
-  void handle(@NotNull E event) throws Exception;
+  private final int order;
+  private final Class<E> eventType;
+  private final NpcEventConsumer<E> consumer;
+
+  private final DefaultNpcEventManager eventManager;
+
+  public DefaultNpcEventSubscription(
+    int order,
+    @NotNull Class<E> eventType,
+    @NotNull NpcEventConsumer<E> consumer,
+    @NotNull DefaultNpcEventManager eventManager
+  ) {
+    this.order = order;
+    this.eventType = eventType;
+    this.consumer = consumer;
+    this.eventManager = eventManager;
+  }
+
+  @Override
+  public int order() {
+    return this.order;
+  }
+
+  @Override
+  public @NotNull Class<E> eventType() {
+    return this.eventType;
+  }
+
+  @Override
+  public @NotNull NpcEventConsumer<E> eventConsumer() {
+    return this.consumer;
+  }
+
+  @Override
+  public void dispose() {
+    this.eventManager.removeSubscription(this);
+  }
 }

--- a/api/src/main/java/com/github/juliarn/npclib/api/event/manager/EventExceptionHandler.java
+++ b/api/src/main/java/com/github/juliarn/npclib/api/event/manager/EventExceptionHandler.java
@@ -24,11 +24,30 @@
 
 package com.github.juliarn.npclib.api.event.manager;
 
-import com.github.juliarn.npclib.api.event.NpcEvent;
 import org.jetbrains.annotations.NotNull;
 
-@FunctionalInterface
-public interface NpcEventConsumer<E extends NpcEvent> {
+final class EventExceptionHandler {
 
-  void handle(@NotNull E event) throws Exception;
+  private EventExceptionHandler() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void rethrowFatalException(@NotNull Throwable throwable) {
+    if (isFatal(throwable)) {
+      throwUnchecked(throwable);
+    }
+  }
+
+  private static boolean isFatal(@NotNull Throwable throwable) {
+    // this includes the most fatal errors that can occur on a thread which we should not silently ignore and rethrow
+    return throwable instanceof InterruptedException
+      || throwable instanceof LinkageError
+      || throwable instanceof ThreadDeath
+      || throwable instanceof VirtualMachineError;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Throwable> void throwUnchecked(@NotNull Throwable throwable) throws T {
+    throw (T) throwable;
+  }
 }

--- a/api/src/main/java/com/github/juliarn/npclib/api/event/manager/NpcEventManager.java
+++ b/api/src/main/java/com/github/juliarn/npclib/api/event/manager/NpcEventManager.java
@@ -27,6 +27,7 @@ package com.github.juliarn.npclib.api.event.manager;
 import com.github.juliarn.npclib.api.event.NpcEvent;
 import com.github.juliarn.npclib.api.log.PlatformLogger;
 import java.util.Objects;
+import java.util.function.Predicate;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,14 +39,17 @@ public interface NpcEventManager {
     return new DefaultNpcEventManager(debugEnabled, logger);
   }
 
+  @Contract("_ -> param1")
   <E extends NpcEvent> @NotNull E post(@NotNull E event);
 
-  <E extends NpcEvent> @NotNull NpcEventManager registerEventHandler(
+  <E extends NpcEvent> @NotNull NpcEventSubscription<? super E> registerEventHandler(
     @NotNull Class<E> eventType,
     @NotNull NpcEventConsumer<E> consumer);
 
-  <E extends NpcEvent> @NotNull NpcEventManager registerEventHandler(
+  <E extends NpcEvent> @NotNull NpcEventSubscription<? super E> registerEventHandler(
     @NotNull Class<E> eventType,
     @NotNull NpcEventConsumer<E> consumer,
     int eventHandlerPriority);
+
+  void unregisterEventHandlerIf(@NotNull Predicate<NpcEventSubscription<? super NpcEvent>> subscriptionFilter);
 }

--- a/api/src/main/java/com/github/juliarn/npclib/api/event/manager/NpcEventSubscription.java
+++ b/api/src/main/java/com/github/juliarn/npclib/api/event/manager/NpcEventSubscription.java
@@ -27,8 +27,13 @@ package com.github.juliarn.npclib.api.event.manager;
 import com.github.juliarn.npclib.api.event.NpcEvent;
 import org.jetbrains.annotations.NotNull;
 
-@FunctionalInterface
-public interface NpcEventConsumer<E extends NpcEvent> {
+public interface NpcEventSubscription<E extends NpcEvent> {
 
-  void handle(@NotNull E event) throws Exception;
+  int order();
+
+  @NotNull Class<E> eventType();
+
+  @NotNull NpcEventConsumer<E> eventConsumer();
+
+  void dispose();
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ checkstyleTools = "10.12.2"
 gson = "2.10.1"
 netty = "4.1.96.Final"
 annotations = "24.0.1"
-event = "1.0.0-SNAPSHOT"
 
 # platform api versions
 sponge = "10.0.0"
@@ -26,7 +25,6 @@ packetEvents = "800ffafb96"
 [libraries]
 
 # general
-event = { group = "com.seiama", name = "event-api", version.ref = "event" }
 netty = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }


### PR DESCRIPTION
The first event lib that we used got deprecated in favor of a new one, which silently started to require Java 17 - this violates our contract to support Java 8. Therefore, insteead of relying on an external lib I moved the event handling into the project now.

Fixes #111