### PR TITLE
Do not keep player in trackedPlayers if the Pre track event was cance…

### DIFF
--- a/common/src/main/java/com/github/juliarn/npclib/common/npc/CommonNpc.java
+++ b/common/src/main/java/com/github/juliarn/npclib/common/npc/CommonNpc.java
@@ -183,13 +183,14 @@ public class CommonNpc<W, P, I, E> extends CommonNpcFlaggedObject implements Npc
   @Override
   public @NotNull Npc<W, P, I, E> forceTrackPlayer(@NotNull P player) {
     // check if the player is not already tracked
-    if (this.trackedPlayers.add(player)) {
+    if (!this.trackedPlayers.contains(player)) {
       // break early if the add is not wanted by plugin
       if (this.platform.eventManager().post(DefaultShowNpcEvent.pre(this, player)).cancelled()) {
-        // trackedPlayers should not include this player if tracking it has been cancelled.
-        this.trackedPlayers.remove(player);
         return this;
       }
+
+      // add the player
+      this.trackedPlayers.add(player);
 
       // send the player info packet
       this.platform.packetFactory().createPlayerInfoPacket(PlayerInfoAction.ADD_PLAYER).schedule(player, this);

--- a/common/src/main/java/com/github/juliarn/npclib/common/npc/CommonNpc.java
+++ b/common/src/main/java/com/github/juliarn/npclib/common/npc/CommonNpc.java
@@ -186,6 +186,8 @@ public class CommonNpc<W, P, I, E> extends CommonNpcFlaggedObject implements Npc
     if (this.trackedPlayers.add(player)) {
       // break early if the add is not wanted by plugin
       if (this.platform.eventManager().post(DefaultShowNpcEvent.pre(this, player)).cancelled()) {
+        // trackedPlayers should not include this player if tracking it has been cancelled.
+        this.trackedPlayers.remove(player);
         return this;
       }
 


### PR DESCRIPTION
This is perhaps not the the best way go to about it, but in our case this was causing an issue. 

If you hadn't otherwise provided a tracking rule, but still wanted to cancel the pre track event, you could never subsequently track an NPC because the player was already in the trackedPlayers collection, despite having been cancelled.