### PR TITLE
chore: remove shadow and stop relocating & shading libraries

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -22,13 +22,7 @@
  * THE SOFTWARE.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 dependencies {
   compileOnly(libs.gson)
   implementation(libs.geantyref)
-}
-
-tasks.withType<ShadowJar> {
-  relocate("io.leangen.geantyref", "com.github.juliarn.npclib.relocate.geantyref")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,10 @@
  */
 
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   alias(libs.plugins.spotless)
   alias(libs.plugins.nexusPublish)
-  alias(libs.plugins.shadow) apply false
 }
 
 defaultTasks("build", "shadowJar")
@@ -71,7 +69,6 @@ subprojects {
   apply(plugin = "java-library")
   apply(plugin = "maven-publish")
   apply(plugin = "com.diffplug.spotless")
-  apply(plugin = "io.github.goooler.shadow")
 
   dependencies {
     "compileOnly"(rootProject.libs.annotations)
@@ -85,15 +82,6 @@ subprojects {
   tasks.withType<Jar> {
     from(rootProject.file("license.txt"))
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
-  }
-
-  tasks.withType<ShadowJar> {
-    archiveClassifier.set(null as String?)
-    dependencies {
-      // excludes the META-INF directory, module infos & html files of all dependencies
-      // this includes for example maven lib files & multi-release module-json files
-      exclude("META-INF/**", "**/*.html", "module-info.*")
-    }
   }
 
   tasks.withType<JavaCompile>().configureEach {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -22,11 +22,9 @@
  * THE SOFTWARE.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 dependencies {
   api(projects.npcLibApi)
-  implementation(projects.npcLibCommon)
+  api(projects.npcLibCommon)
 
   implementation(libs.paperLib)
   implementation(libs.geantyref)
@@ -35,18 +33,4 @@ dependencies {
   compileOnly(libs.netty)
   compileOnly(libs.paper)
   compileOnly(libs.protocolLib)
-}
-
-tasks.withType<ShadowJar> {
-  dependsOn(":npc-lib-common:shadowJar")
-
-  relocate("net.kyori", "com.github.juliarn.npclib.relocate.net.kyori")
-  relocate("io.papermc.lib", "com.github.juliarn.npclib.relocate.paperlib")
-  relocate("io.leangen.geantyref", "com.github.juliarn.npclib.relocate.geantyref")
-  relocate("io.github.retrooper", "com.github.juliarn.npclib.relocate.io.packetevents")
-  relocate("com.github.retrooper", "com.github.juliarn.npclib.relocate.com.packetevents")
-
-  dependencies {
-    exclude("plugin.yml")
-  }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,36 +22,6 @@
  * THE SOFTWARE.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
-/*
- * This file is part of npc-lib, licensed under the MIT License (MIT).
- *
- * Copyright (c) 2022 Julian M., Pasqual K. and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-
 dependencies {
   api(projects.npcLibApi)
-}
-
-tasks.withType<ShadowJar> {
-  dependsOn(":npc-lib-api:shadowJar")
 }

--- a/ext/labymod/build.gradle.kts
+++ b/ext/labymod/build.gradle.kts
@@ -22,8 +22,6 @@
  * THE SOFTWARE.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 dependencies {
   compileOnly(libs.gson)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 
 # plugins
-shadow = "8.1.8"
 spotless = "6.25.0"
 nexusPublish = "2.0.0"
 checkstyleTools = "10.17.0"
@@ -46,6 +45,5 @@ checkstyleTools = { group = "com.puppycrawl.tools", name = "checkstyle", version
 
 [plugins]
 
-shadow = { id = "io.github.goooler.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/minestom/build.gradle.kts
+++ b/minestom/build.gradle.kts
@@ -22,11 +22,9 @@
  * THE SOFTWARE.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 dependencies {
   api(projects.npcLibApi)
-  implementation(projects.npcLibCommon)
+  api(projects.npcLibCommon)
 
   compileOnly(libs.minestom)
   implementation(libs.geantyref)
@@ -34,9 +32,4 @@ dependencies {
 
 tasks.withType<JavaCompile> {
   options.release.set(17)
-}
-
-tasks.withType<ShadowJar> {
-  dependsOn(":npc-lib-common:shadowJar")
-  relocate("io.leangen.geantyref", "com.github.juliarn.npclib.relocate.geantyref")
 }


### PR DESCRIPTION
The shading done by this library is not really great. Including the library (and shading it) causes the shaded libs to appear multiple times in the final jar (one relocated version and the "normal" version).